### PR TITLE
Release v5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is designed to be flexible and easy to use, and supports the following types 
 
 ## JDK Version
 
-Blur is built on JDK 21. For projects using JDK 1.8 or later, please refer to this [user guide](https://github.com/allurx/blur/tree/v2.4.6).
+Blur requires JDK 25 or later. For projects using older JDK versions, see the [v2.4.6 user guide](https://github.com/allurx/blur/tree/v2.4.6) for the Java 8-compatible version.
 
 ## Maven Dependency
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,16 +14,16 @@
     </description>
 
     <properties>
-        <annotation-parser.version>2.1.1</annotation-parser.version>
-        <junit-jupiter.version>5.11.0</junit-jupiter.version>
-        <maven.compiler.source.version>21</maven.compiler.source.version>
-        <maven.compiler.target.version>21</maven.compiler.target.version>
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-javadoc-plugin.version>3.10.0</maven-javadoc-plugin.version>
-        <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
-        <maven-central-publishing-plugin.version>0.5.0</maven-central-publishing-plugin.version>
+        <annotation-parser.version>3.0.0</annotation-parser.version>
+        <junit-jupiter.version>6.1.3</junit-jupiter.version>
+        <maven.compiler.release>25</maven.compiler.release>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-central-publishing-plugin.version>0.11.0</maven-central-publishing-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -68,34 +68,25 @@
         </dependency>
     </dependencies>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Nexus Snapshots Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <source>${maven.compiler.source.version}</source>
-                    <target>${maven.compiler.target.version}</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>${maven-resources-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <useModulePath>true</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -103,9 +94,6 @@
     <profiles>
         <profile>
             <id>release</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -120,9 +108,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                        <configuration>
-                            <attach>true</attach>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.allurx</groupId>
     <artifactId>blur</artifactId>
-    <version>4.1.0</version>
+    <version>5.0.0</version>
     <name>blur</name>
     <url>https://github.com/allurx/blur</url>
     <description>

--- a/src/main/java/io/allurx/blur/handler/AbstractCharSequenceHandler.java
+++ b/src/main/java/io/allurx/blur/handler/AbstractCharSequenceHandler.java
@@ -17,7 +17,7 @@
 package io.allurx.blur.handler;
 
 import io.allurx.annotation.parser.handler.AnnotationHandler;
-import io.allurx.annotation.parser.util.InstanceCreators;
+import io.allurx.annotation.parser.util.Instances;
 import io.allurx.blur.annotation.Condition;
 
 import java.lang.annotation.Annotation;
@@ -58,7 +58,7 @@ public abstract class AbstractCharSequenceHandler<T extends CharSequence, A exte
     public boolean required(T input, Class<? extends Condition<?>> conditionClass) {
         @SuppressWarnings("unchecked")
         Class<? extends Condition<T>> clazz = (Class<? extends Condition<T>>) conditionClass;
-        return InstanceCreators.find(clazz).create().required(input);
+        return Instances.create(clazz).required(input);
     }
 
     /**

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -19,8 +19,7 @@
  * @author allurx
  */
 module io.allurx.blur {
-    requires io.allurx.kit.base;
-    requires io.allurx.annotation.parser;
+    requires transitive io.allurx.annotation.parser;
     exports io.allurx.blur;
     exports io.allurx.blur.annotation;
     exports io.allurx.blur.handler;

--- a/src/test/java/io/allurx/blur/test/ConditionTest.java
+++ b/src/test/java/io/allurx/blur/test/ConditionTest.java
@@ -15,6 +15,7 @@
  */
 package io.allurx.blur.test;
 
+import io.allurx.annotation.parser.util.Singletons;
 import io.allurx.blur.Blur;
 import io.allurx.blur.annotation.Condition;
 import io.allurx.blur.annotation.Strings;
@@ -32,6 +33,32 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * @author allurx
  */
 class ConditionTest {
+
+    @Test
+    void reusesConditionAcrossBlurCalls() {
+        Singletons.remove(FirstCallCondition.class);
+        try {
+            var typeToken = new AnnotatedTypeToken<@Strings(condition = FirstCallCondition.class) String>() {
+            };
+
+            assertEquals("******", Blur.blur("123456", typeToken));
+            assertEquals("123456", Blur.blur("123456", typeToken));
+        } finally {
+            Singletons.remove(FirstCallCondition.class);
+        }
+    }
+
+    private static class FirstCallCondition implements Condition<String> {
+
+        private boolean firstCall = true;
+
+        @Override
+        public boolean required(String input) {
+            boolean required = firstCall;
+            firstCall = false;
+            return required;
+        }
+    }
 
     @Test
     void blur() {

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -21,8 +21,6 @@
 module io.allurx.blur.test {
     requires org.junit.jupiter;
     requires io.allurx.blur;
-    requires io.allurx.kit.base;
-    requires io.allurx.annotation.parser;
     opens io.allurx.blur.test;
     opens io.allurx.blur.test.model;
 }


### PR DESCRIPTION
Upgrade Blur to 5.0.0 with annotation-parser 3.0.0 and require JDK 25 or later.

- Restore Condition singleton semantics by creating instances through Instances.create, with a regression test that preserves condition state across blur calls.
- Expose annotation-parser and kit-base through transitive module dependencies. Remove direct dependency declarations from the test module to verify the public module contract.
- Update the Maven toolchain, release profile, project version, and JDK documentation.

Validation:
- mvn -o clean verify: all 7 tests pass and blur-5.0.0.jar builds successfully.
- The singleton regression fails before the fix and passes afterward.
- Independent JPMS consumer compilation and execution passed for type-token masking and Handler extension during the compatibility fix.

Breaking change: the minimum supported JDK increases from 21 to 25.

Commits:
- e7c86dc fix!: adapt to annotation-parser 3.0.0
- 686ce61 chore(release): bump version to 5.0.0
